### PR TITLE
Make `cynic` py3 compatible

### DIFF
--- a/cynic/handlers/base.py
+++ b/cynic/handlers/base.py
@@ -24,7 +24,7 @@
 
 __author__ = 'Ruslan Spivak <ruslan.spivak@gmail.com>'
 
-from BaseHTTPServer import BaseHTTPRequestHandler
+from http.server import BaseHTTPRequestHandler
 
 from cynic.utils import get_stream_logger # do not call at module level
 

--- a/cynic/server.py
+++ b/cynic/server.py
@@ -31,8 +31,8 @@ import socket
 import select
 import signal
 import optparse
-import StringIO
-import ConfigParser
+import io
+import configparser
 
 from cynic.utils import LOG_UNIX_SOCKET, get_console_logger, get_stream_logger
 
@@ -151,7 +151,7 @@ def _reap_children(signum, frame):
 
 def _load_config(fname):
     """Return an instance of ConfigParser."""
-    config = ConfigParser.ConfigParser()
+    config = configparser.ConfigParser()
     if hasattr(fname, 'readline'):
         config.readfp(fname)
     else:
@@ -339,15 +339,14 @@ def main():
     options, args = parser.parse_args()
 
     if options.dump:
-        print DEFAULT_CONFIG
+        print(DEFAULT_CONFIG)
         sys.exit(0)
 
     path = options.config_path
     if path is None:
-        path = StringIO.StringIO(DEFAULT_CONFIG)
+        path = io.StringIO(DEFAULT_CONFIG)
 
     config = _load_config(path)
     handlers = _get_handler_configs(config)
     ioloop = IOLoop(handlers)
     ioloop.run()
-

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -40,8 +40,8 @@ source_suffix = '.rst'
 master_doc = 'index'
 
 # General information about the project.
-project = u'cynic'
-copyright = u'2012, Ruslan Spivak'
+project = 'cynic'
+copyright = '2012, Ruslan Spivak'
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the
@@ -183,8 +183,8 @@ latex_elements = {
 # Grouping the document tree into LaTeX files. List of tuples
 # (source start file, target name, title, author, documentclass [howto/manual]).
 latex_documents = [
-  ('index', 'cynic.tex', u'cynic Documentation',
-   u'Ruslan Spivak', 'manual'),
+  ('index', 'cynic.tex', 'cynic Documentation',
+   'Ruslan Spivak', 'manual'),
 ]
 
 # The name of an image file (relative to this directory) to place at the top of
@@ -213,8 +213,8 @@ latex_documents = [
 # One entry per manual page. List of tuples
 # (source start file, name, description, authors, manual section).
 man_pages = [
-    ('index', 'cynic', u'cynic Documentation',
-     [u'Ruslan Spivak'], 1)
+    ('index', 'cynic', 'cynic Documentation',
+     ['Ruslan Spivak'], 1)
 ]
 
 # If true, show URL addresses after external links.
@@ -227,8 +227,8 @@ man_pages = [
 # (source start file, target name, title, author,
 #  dir menu entry, description, category)
 texinfo_documents = [
-  ('index', 'cynic', u'cynic Documentation',
-   u'Ruslan Spivak', 'cynic', 'One line description of project.',
+  ('index', 'cynic', 'cynic Documentation',
+   'Ruslan Spivak', 'cynic', 'One line description of project.',
    'Miscellaneous'),
 ]
 

--- a/setup.py
+++ b/setup.py
@@ -56,6 +56,6 @@ setup(
     [console_scripts]
     cynic = cynic.server:main
     """,
-    classifiers=filter(None, classifiers.split('\n')),
+    classifiers=[x for x in classifiers.split('\n') if x],
     long_description=read('README.rst') + '\n\n' + read('CHANGES.rst'),
     )


### PR DESCRIPTION
Unfortunately, `cynic` has no tests to run to prove it works both with py2 and py3 as well. So I had run it with our production tests and they passed fine.
